### PR TITLE
fix: remove deprecated jquery.putcursoratend.js lib

### DIFF
--- a/assets/javascripts/wizard-custom.js
+++ b/assets/javascripts/wizard-custom.js
@@ -107,7 +107,6 @@
 //= require preload-store
 //= require lodash.js
 //= require mousetrap.js
-//= require jquery.putcursoratend.js
 //= require template_include.js
 //= require caret_position.js
 //= require popper.js


### PR DESCRIPTION
This PR removes `jquery.putcursoratend.js` lib that was removed from Discourse here https://github.com/discourse/discourse/pull/9390

Looks like we are not using this library at all and it's just here as a dependency for the composer.

