### PR TITLE
FIX: discourse now uses helperContext to fetch siteSettings on frontend

### DIFF
--- a/assets/javascripts/wizard/initializers/custom.js.es6
+++ b/assets/javascripts/wizard/initializers/custom.js.es6
@@ -22,6 +22,7 @@ export default {
     const Singleton = requirejs("discourse/mixins/singleton").default;
     const Store = requirejs("discourse/models/store").default;
     const registerRawHelpers = requirejs("discourse-common/lib/raw-handlebars-helpers").registerRawHelpers;
+    const createHelperContext = requirejs("discourse-common/lib/helpers").createHelperContext;
     const RawHandlebars = requirejs("discourse-common/lib/raw-handlebars").default;
     const Site = requirejs("discourse/plugins/discourse-custom-wizard/wizard/models/site").default;
     const RestAdapter = requirejs("discourse/adapters/rest").default;
@@ -49,6 +50,7 @@ export default {
 
     const siteSettings = Wizard.SiteSettings;
     app.register("site-settings:main", siteSettings, { instantiate: false });
+    createHelperContext(siteSettings);
     targets.forEach(t => app.inject(t, "siteSettings", "site-settings:main"));
     
     app.register("service:store", Store);


### PR DESCRIPTION
- Discourse now uses `helperContext` to fetch `siteSettings` so this is required to make the components like `tag-chooser` work on the wizard side of things.

Discussed [here](https://meta.discourse.org/t/moving-away-from-discourse-sitesettings-an-upgrading-guide/158977)