### PR TITLE
removed PrettyText processing for field labels

### DIFF
--- a/extensions/wizard_field.rb
+++ b/extensions/wizard_field.rb
@@ -25,6 +25,6 @@ module CustomWizardFieldExtension
   end
 
   def label
-    @label ||= PrettyText.cook(@attrs[:label])
+    @label ||= @attrs[:label]
   end
 end


### PR DESCRIPTION
- This simply adds a `p` tag to the label which is serialized back to the client which prevents us from using the label for some functionality. It doesn't affect the style.