### PR TITLE
Item chooser

### DIFF
--- a/assets/javascripts/wizard-custom.js
+++ b/assets/javascripts/wizard-custom.js
@@ -94,6 +94,7 @@
 //= require discourse/app/components/date-time-input
 //= require discourse/app/components/text-field
 //= require discourse/app/components/d-textarea
+//= require discourse/app/components/topic-list
 
 //= require discourse/app/templates/components/conditional-loading-spinner
 //= require discourse/app/templates/components/d-button

--- a/assets/javascripts/wizard/components/item-chooser.js.es6
+++ b/assets/javascripts/wizard/components/item-chooser.js.es6
@@ -1,0 +1,36 @@
+import MiniTagChooser from "select-kit/components/mini-tag-chooser";
+import { ajax } from "discourse/lib/ajax";
+import { observes } from "discourse-common/utils/decorators";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export default MiniTagChooser.extend({
+  searchTags(url, data, callback){
+    return ajax(url, {
+      data: {
+        name: data.name,
+        value: data.q,
+      }
+    }).then(result => callback(this, result))
+      .catch(popupAjaxError);
+  },
+
+  search(filter){
+    const data = {
+      q: filter,
+      name: this.get('item')
+    }
+
+    return this.searchTags('/w/items/search', data, this._transformJson );
+
+  },
+
+
+  _transformJson(obj, result){
+    let x = result.map(item => {
+      return { id: item, name: item }
+    })
+
+    return x ;
+  },
+
+});

--- a/assets/javascripts/wizard/components/wizard-field-item-chooser.js.es6
+++ b/assets/javascripts/wizard/components/wizard-field-item-chooser.js.es6
@@ -1,0 +1,14 @@
+import Component from "@ember/component";
+import discourseComputed, { observes } from 'discourse-common/utils/decorators';
+
+export default Component.extend({
+  @observes('value')
+  updateValue(){
+    this.set('field.value', this.value.join(','));
+  },
+
+  @discourseComputed('field.label')
+  itemName(label){
+    return label.replace(/(<([^>]+)>)/gi, "");
+  }
+});

--- a/assets/javascripts/wizard/templates/components/wizard-field-item-chooser.hbs
+++ b/assets/javascripts/wizard/templates/components/wizard-field-item-chooser.hbs
@@ -1,0 +1,1 @@
+{{item-chooser value=value item=itemName}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -171,6 +171,7 @@ en:
             date: Date
             time: Time
             date_time: Date & Time
+            item_chooser: Item Chooser
         
         connector:
           and: "and"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ CustomWizard::Engine.routes.draw do
   get ':wizard_id/steps' => 'wizard#index'
   get ':wizard_id/steps/:step_id' => 'wizard#index'
   put ':wizard_id/steps/:step_id' => 'steps#update'
+  get 'items/search' => 'items#search'
 end
 
 Discourse::Application.routes.append do

--- a/controllers/custom_wizard/item.rb
+++ b/controllers/custom_wizard/item.rb
@@ -1,0 +1,12 @@
+class CustomWizard::ItemsController < ::ApplicationController
+  def search
+    search_params = {
+      name: params[:name],
+      value: params[:value] || '',
+      limit: params[:limit] || 5
+    }
+    items = CustomWizard::Item.search(search_params)
+
+    render json: MultiJson.dump(items)
+  end
+end

--- a/lib/custom_wizard/field.rb
+++ b/lib/custom_wizard/field.rb
@@ -49,7 +49,8 @@ class CustomWizard::Field
         prefill: nil,
         content: nil
       },
-      user_selector: {}
+      user_selector: {},
+      item_chooser: {}
     }
   end
 

--- a/lib/custom_wizard/item.rb
+++ b/lib/custom_wizard/item.rb
@@ -1,0 +1,18 @@
+class CustomWizard::Item
+  WIZARD_ITEM = 'wizard_item'.freeze
+
+  def initialize(name, value)
+    @name = name
+    @value = value
+  end
+
+  def save
+    PluginStore.set(WIZARD_ITEM, @name, @value)
+  end
+
+  def self.search(params)
+    items = PluginStore.get(WIZARD_ITEM, params[:name])
+    items ? items.filter{ |string| string.downcase.include?(params[:value].downcase) }.take(params[:limit] || 5)
+          : []
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -53,6 +53,7 @@ after_initialize do
     ../controllers/custom_wizard/wizard.rb
     ../controllers/custom_wizard/steps.rb
     ../controllers/custom_wizard/transfer.rb
+    ../controllers/custom_wizard/item.rb
     ../jobs/clear_after_time_wizard.rb
     ../jobs/refresh_api_access_token.rb
     ../jobs/set_after_time_wizard.rb
@@ -61,6 +62,7 @@ after_initialize do
     ../lib/custom_wizard/builder.rb
     ../lib/custom_wizard/field.rb
     ../lib/custom_wizard/mapper.rb
+    ../lib/custom_wizard/item.rb
     ../lib/custom_wizard/log.rb
     ../lib/custom_wizard/step_updater.rb
     ../lib/custom_wizard/validator.rb


### PR DESCRIPTION
- It added a field type called `item chooser` similar to the tag chooser.
- currently, the list of available items need to be exported via the script/console
- You can save the array of items to any custom field or user field.

Improvements required: 
- it uses the `label` field to set the `item name`. It should add a proper text field instead.
- The items should be able to be added dynamically like tags.