### PR TITLE
Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/wizard-custom.js
+++ b/assets/javascripts/wizard-custom.js
@@ -14,7 +14,6 @@
 //= require discourse/app/lib/notification-levels
 //= require discourse/app/lib/computed
 //= require discourse/app/lib/user-search
-//= require discourse/app/lib/debounce
 //= require discourse/app/lib/text
 //= require discourse/app/lib/formatter
 //= require discourse/app/lib/quote
@@ -85,6 +84,7 @@
 //= require discourse-common/addon/helpers/component-for-collection
 //= require discourse-common/addon/helpers/component-for-row
 //= require discourse-common/addon/lib/raw-templates
+//= require discourse-common/lib/debounce
 //= require discourse/app/helpers/discourse-tag
 
 //= require discourse/app/services/app-events

--- a/assets/javascripts/wizard-custom.js
+++ b/assets/javascripts/wizard-custom.js
@@ -84,7 +84,6 @@
 //= require discourse-common/addon/helpers/component-for-collection
 //= require discourse-common/addon/helpers/component-for-row
 //= require discourse-common/addon/lib/raw-templates
-//= require discourse-common/lib/debounce
 //= require discourse/app/helpers/discourse-tag
 
 //= require discourse/app/services/app-events

--- a/assets/javascripts/wizard/lib/user-search.js.es6
+++ b/assets/javascripts/wizard/lib/user-search.js.es6
@@ -1,6 +1,7 @@
 import { CANCELLED_STATUS } from 'discourse/lib/autocomplete';
+import { debounce } from "@ember/runloop";
+import discourseDebounce from "discourse-common/lib/debounce";
 import getUrl from 'discourse-common/lib/get-url';
-import discourseDebounce from "discourse/lib/debounce";
 
 var cache = {},
     cacheTopicId,
@@ -39,8 +40,6 @@ function performSearch(term, topicId, includeGroups, includeMentionableGroups, i
     resultsFn(returnVal);
   });
 }
-
-var debouncedSearch = discourseDebounce(performSearch, 300);
 
 function organizeResults(r, options) {
   if (r === CANCELLED_STATUS) { return r; }
@@ -119,17 +118,26 @@ export default function userSearch(options) {
       resolve(CANCELLED_STATUS);
     }, 5000);
 
-    debouncedSearch(term,
-        topicId,
-        includeGroups,
-        includeMentionableGroups,
-        includeMessageableGroups,
-        allowedUsers,
-        group,
-        function(r) {
-          clearTimeout(clearPromise);
-          resolve(organizeResults(r, options));
-        });
+    // TODO: Use discouseDebounce after the 2.7 release.
+    let debounceFunc = discourseDebounce || debounce;
 
-  });
+    debounceFunc(
+      this,
+      function() {
+        performSearch(
+          term,
+          topicId,
+          includeGroups,
+          includeMentionableGroups,
+          includeMessageableGroups,
+          allowedUsers,
+          group,
+          function(r) {
+            clearTimeout(clearPromise);
+            resolve(organizeResults(r, options));
+          }
+        )
+      },
+      300
+    )
 }

--- a/assets/javascripts/wizard/lib/user-search.js.es6
+++ b/assets/javascripts/wizard/lib/user-search.js.es6
@@ -1,6 +1,5 @@
 import { CANCELLED_STATUS } from 'discourse/lib/autocomplete';
 import { debounce } from "@ember/runloop";
-import discourseDebounce from "discourse-common/lib/debounce";
 import getUrl from 'discourse-common/lib/get-url';
 
 var cache = {},
@@ -118,10 +117,8 @@ export default function userSearch(options) {
       resolve(CANCELLED_STATUS);
     }, 5000);
 
-    // TODO: Use discouseDebounce after the 2.7 release.
-    let debounceFunc = discourseDebounce || debounce;
-
-    debounceFunc(
+    // TODO: Use discouseDebounce after it is available on stable.
+    debounce(
       this,
       function() {
         performSearch(
@@ -140,4 +137,5 @@ export default function userSearch(options) {
       },
       300
     )
+  });
 }


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.