### PR TITLE
base_uri is deprecated (replaced by base_path)

### DIFF
--- a/views/layouts/wizard.html.erb
+++ b/views/layouts/wizard.html.erb
@@ -28,7 +28,7 @@
     <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
 
     <meta name="discourse_theme_ids" content="<%= theme_ids&.join(",") %>">
-    <meta name="discourse-base-uri" content="<%= Discourse.base_uri %>">
+    <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">
 
     <%= render partial: "layouts/head" %>
     <title><%= wizard_page_title %></title>


### PR DESCRIPTION
Ref: https://github.com/discourse/discourse/blob/dc268822a405a23c3dc59a5537d3b72d00d7876f/lib/discourse.rb#L389