### PR TITLE
Ensure SCSS compilation compatibility with core

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -172,7 +172,15 @@ after_initialize do
   ::Wizard::Step.prepend CustomWizardStepExtension
 
   full_path = "#{Rails.root}/plugins/discourse-custom-wizard/assets/stylesheets/wizard/wizard_custom.scss"
-  Stylesheet::Importer.plugin_assets['wizard_custom'] = Set[full_path]
+  if Stylesheet::Importer.respond_to?(:plugin_assets)
+    Stylesheet::Importer.plugin_assets['wizard_custom'] = Set[full_path]
+  else
+    # legacy method, Discourse 2.7.0.beta5 and below
+    DiscoursePluginRegistry.register_asset(full_path, {}, "wizard_custom")
+    Stylesheet::Importer.register_import("wizard_custom") do
+      import_files(DiscoursePluginRegistry.stylesheets["wizard_custom"])
+    end
+  end
 
   CustomWizard::CustomField::CLASSES.keys.each do |klass|
     add_model_callback(klass, :after_initialize) do

--- a/plugin.rb
+++ b/plugin.rb
@@ -94,7 +94,7 @@ after_initialize do
   ].each do |path|
     load File.expand_path(path, __FILE__)
   end
-  
+
   add_class_method(:wizard, :user_requires_completion?) do |user|
     wizard_result = self.new(user).requires_completion?
     return wizard_result if wizard_result
@@ -113,7 +113,7 @@ after_initialize do
 
     !!custom_redirect
   end
-    
+
   add_to_class(:users_controller, :wizard_path) do
     if custom_wizard_redirect = current_user.custom_fields['redirect_to_wizard']
       "#{Discourse.base_url}/w/#{custom_wizard_redirect.dasherize}"
@@ -131,7 +131,7 @@ after_initialize do
       CustomWizard::Wizard.set_wizard_redirect(wizard.id, user)
     end
   end
-  
+
   add_to_class(:application_controller, :redirect_to_wizard_if_required) do
     wizard_id = current_user.custom_fields['redirect_to_wizard']
     @excluded_routes ||= SiteSetting.wizard_redirect_exclude_paths.split('|') + ['/w/']
@@ -146,11 +146,11 @@ after_initialize do
       end
     end
   end
-  
+
   add_to_serializer(:site, :include_wizard_required?) do
     scope.is_admin? && Wizard.new(scope.user).requires_completion?
   end
-  
+
   add_to_serializer(:site, :complete_custom_wizard) do
     if scope.user && requires_completion = CustomWizard::Wizard.prompt_completion(scope.user)
       requires_completion.map {|w| { name: w[:name], url: "/w/#{w[:id]}"} }
@@ -160,23 +160,20 @@ after_initialize do
   add_to_serializer(:site, :include_complete_custom_wizard?) do
     complete_custom_wizard.present?
   end
-  
+
   add_model_callback(:application_controller, :before_action) do
     redirect_to_wizard_if_required if current_user
   end
-  
+
   ::ExtraLocalesController.prepend ExtraLocalesControllerCustomWizard
   ::InvitesController.prepend InvitesControllerCustomWizard
   ::UsersController.prepend CustomWizardUsersController
   ::Wizard::Field.prepend CustomWizardFieldExtension
   ::Wizard::Step.prepend CustomWizardStepExtension
-  
+
   full_path = "#{Rails.root}/plugins/discourse-custom-wizard/assets/stylesheets/wizard/wizard_custom.scss"
-  DiscoursePluginRegistry.register_asset(full_path, {}, "wizard_custom")
-  Stylesheet::Importer.register_import("wizard_custom") do
-    import_files(DiscoursePluginRegistry.stylesheets["wizard_custom"])
-  end
-  
+  Stylesheet::Importer.plugin_assets['wizard_custom'] = Set[full_path]
+
   CustomWizard::CustomField::CLASSES.keys.each do |klass|
     add_model_callback(klass, :after_initialize) do
       if CustomWizard::CustomField.enabled?
@@ -188,10 +185,10 @@ after_initialize do
         end
       end
     end
-    
+
     klass.to_s.classify.constantize.singleton_class.prepend CustomWizardCustomFieldPreloader
   end
-  
+
   CustomWizard::CustomField.serializers.each do |serializer_klass|
     "#{serializer_klass}_serializer".classify.constantize.prepend CustomWizardCustomFieldSerializer
   end

--- a/views/layouts/wizard.html.erb
+++ b/views/layouts/wizard.html.erb
@@ -1,13 +1,13 @@
 <html>
   <head>
     <%= discourse_color_scheme_stylesheets %>
-    
+
     <%= discourse_stylesheet_link_tag :wizard, theme_id: nil %>
     <%= discourse_stylesheet_link_tag :wizard_custom %>
     <%- if wizard_theme_ids.present? %>
       <%= discourse_stylesheet_link_tag (mobile_view? ? :mobile_theme : :desktop_theme), theme_ids: wizard_theme_ids %>
     <%- end %>
-    
+
     <%= preload_script "locales/#{I18n.locale}" %>
     <%= preload_script "ember_jquery" %>
     <%= preload_script "wizard-vendor" %>
@@ -30,7 +30,7 @@
     <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
 
     <meta name="discourse_theme_ids" content="<%= wizard_theme_ids&.join(",") %>">
-    <meta name="discourse-base-uri" content="<%= Discourse.base_uri %>">
+    <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">
 
     <%= render partial: "layouts/head" %>
     <title><%= wizard_page_title %></title>
@@ -40,7 +40,7 @@
     <%- unless customization_disabled? %>
       <%= raw theme_lookup("header") %>
     <%- end %>
-    
+
     <div id='custom-wizard-main'></div>
 
     <%- unless customization_disabled? %>


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/12359 

This fixes an issue with SCSS compilation on an upcoming core change (see PR above). 

It also fixes a minor deprecation, `Discourse.base_uri` is now `Discourse.base_path`. 

(I hope you don't mind the whitespace changes.) 