### PR TITLE
FIX: checkbox description alignment

### DIFF
--- a/assets/stylesheets/wizard/custom/field.scss
+++ b/assets/stylesheets/wizard/custom/field.scss
@@ -46,7 +46,7 @@
     display: flex;
     align-items: center;
 
-    & > .input-area {
+    .input-area {
       order: 0;
       margin: 15px 20px !important;
 


### PR DESCRIPTION
@angusmcleod 
The css expects `.input-area` to be a direct descendant of `.checkbox-field` class. This isn't the case anymore as the `field-validators` contextual component adds an extra div around all the fields.