### PR TITLE
Enable templating 

### DIFF
--- a/lib/custom_wizard/action.rb
+++ b/lib/custom_wizard/action.rb
@@ -499,7 +499,13 @@ class CustomWizard::Action
     ).perform
 
     params[:raw] = action['post_builder'] ?
-      mapper.interpolate(action['post_template']) :
+      mapper.interpolate(
+        action['post_template'],
+        user: true,
+        value: true,
+        wizard: true,
+        template: true
+      ) :
       data[action['post']]
 
     params[:import_mode] = ActiveRecord::Type::Boolean.new.cast(action['suppress_notifications'])

--- a/lib/custom_wizard/builder.rb
+++ b/lib/custom_wizard/builder.rb
@@ -246,6 +246,7 @@ class CustomWizard::Builder
         wizard: true,
         template: true
       )
+      step.description = PrettyText.cook(step.description)
     end
 
     step

--- a/lib/custom_wizard/builder.rb
+++ b/lib/custom_wizard/builder.rb
@@ -177,6 +177,16 @@ class CustomWizard::Builder
       params[:index] = index.to_i unless index.nil?
     end
 
+    if field_template['description'].present?
+      params[:description] = mapper.interpolate(
+        field_template['description'],
+        user: true,
+        value: true,
+        wizard: true,
+        template: true
+      )
+    end
+
     field = step.add_field(params)
   end
 
@@ -232,7 +242,9 @@ class CustomWizard::Builder
       step.description = mapper.interpolate(
         step_template['description'],
         user: true,
-        value: true
+        value: true,
+        wizard: true,
+        template: true
       )
     end
 

--- a/lib/custom_wizard/template.rb
+++ b/lib/custom_wizard/template.rb
@@ -97,10 +97,6 @@ class CustomWizard::Template
 
   def prepare_data
     @data[:steps].each do |step|
-      if step[:raw_description]
-        step[:description] = PrettyText.cook(step[:raw_description])
-      end
-
       remove_non_mapped_index(step)
 
       step[:fields].each do |field|

--- a/lib/custom_wizard/template.rb
+++ b/lib/custom_wizard/template.rb
@@ -97,6 +97,10 @@ class CustomWizard::Template
 
   def prepare_data
     @data[:steps].each do |step|
+      if step[:raw_description]
+        step[:description] = step[:raw_description]
+      end
+
       remove_non_mapped_index(step)
 
       step[:fields].each do |field|

--- a/serializers/custom_wizard/wizard_step_serializer.rb
+++ b/serializers/custom_wizard/wizard_step_serializer.rb
@@ -53,7 +53,7 @@ class CustomWizard::StepSerializer < ::ApplicationSerializer
   end
 
   def description
-    return PrettyText.cook(object.description) if object.description
+    return object.description if object.description
     PrettyText.cook(I18n.t("#{object.key || i18n_key}.description", default: '', base_url: Discourse.base_url))
   end
 

--- a/serializers/custom_wizard/wizard_step_serializer.rb
+++ b/serializers/custom_wizard/wizard_step_serializer.rb
@@ -53,7 +53,7 @@ class CustomWizard::StepSerializer < ::ApplicationSerializer
   end
 
   def description
-    return object.description if object.description
+    return PrettyText.cook(object.description) if object.description
     PrettyText.cook(I18n.t("#{object.key || i18n_key}.description", default: '', base_url: Discourse.base_url))
   end
 

--- a/spec/fixtures/wizard.json
+++ b/spec/fixtures/wizard.json
@@ -46,7 +46,7 @@
           "type": "text_only"
         }
       ],
-      "description": "<p>Text inputs!</p>"
+      "description": "Text inputs!"
     },
     {
       "id": "step_2",
@@ -93,7 +93,7 @@
           "file_types": ".jpg,.jpeg,.png"
         }
       ],
-      "description": "<p>Because I couldn’t think of another name for this step <img src=\"/images/emoji/twitter/slight_smile.png?v=9\" title=\":slight_smile:\" class=\"emoji\" alt=\":slight_smile:\"></p>"
+      "description": "Because I couldn't think of another name for this step :)"
     },
     {
       "id": "step_3",
@@ -160,7 +160,7 @@
           "type": "user_selector"
         }
       ],
-      "description": "<p>Unfortunately not the edible type <img src=\"/images/emoji/twitter/sushi.png?v=9\" title=\":sushi:\" class=\"emoji\" alt=\":sushi:\"></p>"
+      "description": "Unfortunately not the edible type :sushi: "
     }
   ],
   "actions": [


### PR DESCRIPTION
Enabled Templating for
- step and field descriptions
- post builder in create topic action

- Run PrettyText on step description after parsing the template otherwise it messes with the templating code.