### PR TITLE
DEV: checkbox value should default to false

### DIFF
--- a/assets/javascripts/wizard/initializers/custom-wizard-field.js.es6
+++ b/assets/javascripts/wizard/initializers/custom-wizard-field.js.es6
@@ -59,7 +59,7 @@ export default {
     FieldModel.reopen({
       init() {
         this._super(...arguments);
-        if  (this.type === "checkbox") {
+        if (this.type === "checkbox") {
           this.set("value", this.value || false);
         }
       },

--- a/assets/javascripts/wizard/initializers/custom-wizard-field.js.es6
+++ b/assets/javascripts/wizard/initializers/custom-wizard-field.js.es6
@@ -57,6 +57,12 @@ export default {
     ];
 
     FieldModel.reopen({
+      init() {
+        this._super(...arguments);
+        if  (this.type === "checkbox") {
+          this.set("value", this.value || false);
+        }
+      },
       check() {
         if (this.customCheck) {
           return this.customCheck();

--- a/assets/javascripts/wizard/initializers/custom-wizard-field.js.es6
+++ b/assets/javascripts/wizard/initializers/custom-wizard-field.js.es6
@@ -57,12 +57,6 @@ export default {
     ];
 
     FieldModel.reopen({
-      init() {
-        this._super(...arguments);
-        if (this.type === "checkbox") {
-          this.set("value", this.value || false);
-        }
-      },
       check() {
         if (this.customCheck) {
           return this.customCheck();

--- a/lib/custom_wizard/field.rb
+++ b/lib/custom_wizard/field.rb
@@ -31,7 +31,7 @@ class CustomWizard::Field
     @index = attrs[:index]
     @type = attrs[:type]
     @required = !!attrs[:required]
-    @value = attrs[:value]
+    @value = attrs[:value] || default_value
     @description = attrs[:description]
     @image = attrs[:image]
     @key = attrs[:key]
@@ -48,6 +48,12 @@ class CustomWizard::Field
 
   def label
     @label ||= PrettyText.cook(@raw[:label])
+  end
+
+  def default_value
+    if @type == 'checkbox'
+      false
+    end
   end
 
   def self.types

--- a/serializers/custom_wizard/wizard_field_serializer.rb
+++ b/serializers/custom_wizard/wizard_field_serializer.rb
@@ -40,10 +40,6 @@ class CustomWizard::FieldSerializer < ::ApplicationSerializer
     object.value
   end
 
-  def include_value?
-    object.value.present?
-  end
-
   def i18n_key
     @i18n_key ||= "wizard.step.#{object.step.id}.fields.#{object.id}".underscore
   end


### PR DESCRIPTION
~~As per https://mehulkar.com/blog/2019/12/ember-octane-default-values/~~

This is particularly important for conditionality. 
- When a step is entered, the initial value of the checkbox is `null` and once its toggled, only then its value becomes `false` or `true`.
- We should always set the default value as `false` because if the user passes on to the next step without touching the checkbox, the value will be equal to `null` hence, `equal to false` condition won't be satisfied. 