### PR TITLE
FIX: clicking `Maybe Later` was causing 500 error

### DIFF
--- a/controllers/custom_wizard/wizard.rb
+++ b/controllers/custom_wizard/wizard.rb
@@ -11,7 +11,9 @@ class CustomWizard::WizardController < ::ApplicationController
   helper_method :wizard_theme_translations_lookup
 
   def wizard
-    CustomWizard::Wizard.create(params[:wizard_id].underscore, current_user)
+    @builder = CustomWizard::Builder.new(params[:wizard_id].underscore, current_user)
+    @wizard ||= @builder.build
+    @wizard
   end
 
   def wizard_page_title


### PR DESCRIPTION
Issue: Clicking `Maybe Later` on a wizard currently doesn't redirect the user to the site, instead causes 500 error on the server.

Reason: 
We call `final_cleanup!` in the `CustomWizard::WizardController::skip` action. It checks if the wizard is `unfinished?` at some point. 
The following line in `unfinished?` requires the steps to be loaded in the wizard object, which it can't find if the wizard is created using `CustomWizard::Wizard.create`.
https://github.com/paviliondev/discourse-custom-wizard/blob/ceef3f4bc9cd1505ca017ca1c0e54e88415ce08b/lib/custom_wizard/wizard.rb#L151