### PR TITLE
Force second step build to overcome can_access? check

### DIFF
--- a/controllers/custom_wizard/steps.rb
+++ b/controllers/custom_wizard/steps.rb
@@ -23,7 +23,7 @@ class CustomWizard::StepsController < ::ApplicationController
     if updater.success?
       wizard_id = update_params[:wizard_id]
       builder = CustomWizard::Builder.new(wizard_id, current_user)
-      @wizard = builder.build
+      @wizard = builder.build(force: true)
 
       current_step = @wizard.find_step(update[:step_id])
       current_submission = @wizard.current_submission

--- a/lib/custom_wizard/builder.rb
+++ b/lib/custom_wizard/builder.rb
@@ -30,7 +30,7 @@ class CustomWizard::Builder
 
   def build(build_opts = {}, params = {})
     return nil if !SiteSetting.custom_wizard_enabled || !@wizard
-    return @wizard if !@wizard.can_access?
+    return @wizard if !@wizard.can_access? && !build_opts[:force]
 
     build_opts[:reset] = build_opts[:reset] || @wizard.restart_on_revisit
 

--- a/spec/components/custom_wizard/wizard_spec.rb
+++ b/spec/components/custom_wizard/wizard_spec.rb
@@ -173,6 +173,8 @@ describe CustomWizard::Wizard do
     progress_step("step_2", acting_user: trusted_user)
     progress_step("step_3", acting_user: trusted_user)
 
+    @permitted_template["multiple_submissions"] = true
+
     expect(
       CustomWizard::Wizard.new(@permitted_template, trusted_user).can_access?
     ).to eq(true)

--- a/spec/fixtures/wizard.json
+++ b/spec/fixtures/wizard.json
@@ -3,7 +3,6 @@
   "name": "Super Mega Fun Wizard",
   "background": "#333333",
   "save_submissions": true,
-  "multiple_submissions": true,
   "after_signup": false,
   "prompt_completion": false,
   "theme_id": 2,


### PR DESCRIPTION
The can_access? check will fail if the wizard does not allow multiple submissions. This means that on the second build of the wizard on the final step of a single submission wizard, the wizard instance will have no steps, and an error will be thrown when logic assumes it does.

This was not picked up in our spec because our wizard.json fixture had ``multiple_submissions`` set to ``true``. I've set that to false and tweaked the one test that assumed it was true.