### PR TITLE
FIX: add csrf token to all wizard ajax requests in dev

### DIFF
--- a/assets/javascripts/wizard/initializers/custom-wizard.js.es6
+++ b/assets/javascripts/wizard/initializers/custom-wizard.js.es6
@@ -27,8 +27,8 @@ export default {
       .setDefaultOwner;
     const messageBus = requirejs("message-bus-client").default;
     const getToken = requirejs("wizard/lib/ajax").getToken;
-    const setEnvironment = requirejs("discourse-common/config/environment").setEnvironment
-    const isDevelopment = requirejs("discourse-common/config/environment").isDevelopment
+    const setEnvironment = requirejs("discourse-common/config/environment").setEnvironment;
+    const isDevelopment = requirejs("discourse-common/config/environment").isDevelopment;
     const container = app.__container__;
     Discourse.Model = EmberObject.extend();
     Discourse.__container__ = container;
@@ -111,7 +111,7 @@ export default {
       model() {},
     });
 
-    $.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
+    $.ajaxPrefilter(function( options, originalOptions ) {
       if(isDevelopment()) {
         options.data = $.param($.extend(originalOptions.data || {}, {
           authenticity_token: getToken()

--- a/assets/javascripts/wizard/initializers/custom-wizard.js.es6
+++ b/assets/javascripts/wizard/initializers/custom-wizard.js.es6
@@ -26,7 +26,9 @@ export default {
     const setDefaultOwner = requirejs("discourse-common/lib/get-owner")
       .setDefaultOwner;
     const messageBus = requirejs("message-bus-client").default;
-
+    const getToken = requirejs("wizard/lib/ajax").getToken;
+    const setEnvironment = requirejs("discourse-common/config/environment").setEnvironment
+    const isDevelopment = requirejs("discourse-common/config/environment").isDevelopment
     const container = app.__container__;
     Discourse.Model = EmberObject.extend();
     Discourse.__container__ = container;
@@ -89,6 +91,7 @@ export default {
     const session = container.lookup("session:main");
     const setupData = document.getElementById("data-discourse-setup").dataset;
     session.set("highlightJsPath", setupData.highlightJsPath);
+    setEnvironment(setupData.environment);
 
     Router.reopen({
       rootURL: getUrl("/w/"),
@@ -106,6 +109,14 @@ export default {
         this.transitionTo("custom");
       },
       model() {},
+    });
+
+    $.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
+      if(isDevelopment()) {
+        options.data = $.param($.extend(originalOptions.data || {}, {
+          authenticity_token: getToken()
+        }));
+      }
     });
   },
 };

--- a/assets/javascripts/wizard/initializers/custom-wizard.js.es6
+++ b/assets/javascripts/wizard/initializers/custom-wizard.js.es6
@@ -27,8 +27,10 @@ export default {
       .setDefaultOwner;
     const messageBus = requirejs("message-bus-client").default;
     const getToken = requirejs("wizard/lib/ajax").getToken;
-    const setEnvironment = requirejs("discourse-common/config/environment").setEnvironment;
-    const isDevelopment = requirejs("discourse-common/config/environment").isDevelopment;
+    const setEnvironment = requirejs("discourse-common/config/environment")
+      .setEnvironment;
+    const isDevelopment = requirejs("discourse-common/config/environment")
+      .isDevelopment;
     const container = app.__container__;
     Discourse.Model = EmberObject.extend();
     Discourse.__container__ = container;
@@ -111,11 +113,9 @@ export default {
       model() {},
     });
 
-    $.ajaxPrefilter(function( options, originalOptions ) {
-      if(isDevelopment()) {
-        options.data = $.param($.extend(originalOptions.data || {}, {
-          authenticity_token: getToken()
-        }));
+    $.ajaxPrefilter(function (_, __, jqXHR) {
+      if (isDevelopment()) {
+        jqXHR.setRequestHeader("X-CSRF-Token", getToken());
       }
     });
   },

--- a/lib/custom_wizard/field.rb
+++ b/lib/custom_wizard/field.rb
@@ -77,7 +77,6 @@ class CustomWizard::Field
         char_counter: nil
       },
       text_only: {},
-      composer_preview: {},
       date: {
         format: "YYYY-MM-DD"
       },

--- a/lib/custom_wizard/field.rb
+++ b/lib/custom_wizard/field.rb
@@ -77,6 +77,7 @@ class CustomWizard::Field
         char_counter: nil
       },
       text_only: {},
+      composer_preview: {},
       date: {
         format: "YYYY-MM-DD"
       },


### PR DESCRIPTION
We get `BAD CSRF` errors for some ajax calls in dev. This is not reproducible on production though. This code intercepts all the ajax calls on the wizard side and adds the `X-CSRF-Token` header to them in dev mode.