### PR TITLE
FIX: clear site model cache to prevent spec failure

### DIFF
--- a/spec/components/custom_wizard/wizard_spec.rb
+++ b/spec/components/custom_wizard/wizard_spec.rb
@@ -199,6 +199,7 @@ describe CustomWizard::Wizard do
   end
 
   it "lists the site categories" do
+    Site.clear_cache
     expect(@wizard.categories.length).to eq(1)
   end
 


### PR DESCRIPTION
@angusmcleod 
The categories are cached by the `Site` model class. We need to purge the cache so that we fetch the accurate list.
Here's a list of failed workflow runs we've had. The reason IMHO is the sequence of tests. https://github.com/paviliondev/discourse-custom-wizard/actions?query=is%3Afailure+workflow%3Aplugin-tests