### PR TITLE
FIX: clear submission if skipped by user

### DIFF
--- a/controllers/custom_wizard/wizard.rb
+++ b/controllers/custom_wizard/wizard.rb
@@ -69,6 +69,7 @@ class CustomWizard::WizardController < ::ApplicationController
       end
 
       submission.remove if submission.present?
+      wizard.reset_user_progress!
     end
 
     render json: result

--- a/controllers/custom_wizard/wizard.rb
+++ b/controllers/custom_wizard/wizard.rb
@@ -68,7 +68,7 @@ class CustomWizard::WizardController < ::ApplicationController
         result.merge!(redirect_to: submission.redirect_to)
       end
 
-      wizard.final_cleanup!
+      submission.remove if submission.present?
     end
 
     render json: result

--- a/controllers/custom_wizard/wizard.rb
+++ b/controllers/custom_wizard/wizard.rb
@@ -69,6 +69,7 @@ class CustomWizard::WizardController < ::ApplicationController
       end
 
       submission.remove if submission.present?
+      wizard.cleanup!
     end
 
     render json: result

--- a/controllers/custom_wizard/wizard.rb
+++ b/controllers/custom_wizard/wizard.rb
@@ -69,7 +69,6 @@ class CustomWizard::WizardController < ::ApplicationController
       end
 
       submission.remove if submission.present?
-      wizard.cleanup!
     end
 
     render json: result

--- a/controllers/custom_wizard/wizard.rb
+++ b/controllers/custom_wizard/wizard.rb
@@ -69,7 +69,7 @@ class CustomWizard::WizardController < ::ApplicationController
       end
 
       submission.remove if submission.present?
-      wizard.reset_user_progress!
+      wizard.reset
     end
 
     render json: result

--- a/lib/custom_wizard/submission.rb
+++ b/lib/custom_wizard/submission.rb
@@ -103,7 +103,7 @@ class CustomWizard::Submission
       wizard_id = submission.wizard.id
       submission_id = submission.id
       data = PluginStore.get("#{wizard_id}_#{KEY}", user_id)
-      data.delete_if { |sub| sub["id"] == submission_id}
+      data.delete_if { |sub| sub["id"] == submission_id }
       PluginStore.set("#{wizard_id}_#{KEY}", user_id, data)
     end
   end

--- a/lib/custom_wizard/submission.rb
+++ b/lib/custom_wizard/submission.rb
@@ -97,6 +97,21 @@ class CustomWizard::Submission
     new(wizard, data, user_id)
   end
 
+  def self.remove(submission)
+    if submission.present?
+      user_id = submission.user.id
+      wizard_id = submission.wizard.id
+      submission_id = submission.id
+      data = PluginStore.get("#{wizard_id}_#{KEY}", user_id)
+      data.delete_if { |sub| sub["id"] == submission_id}
+      PluginStore.set("#{wizard_id}_#{KEY}", user_id, data)
+    end
+  end
+
+  def remove
+    self.class.remove(self)
+  end
+
   def self.cleanup_incomplete_submissions(wizard)
     user_id = wizard.user.id
     all_submissions = list(wizard, user_id: user_id)

--- a/lib/custom_wizard/submission.rb
+++ b/lib/custom_wizard/submission.rb
@@ -97,10 +97,6 @@ class CustomWizard::Submission
     new(wizard, data, user_id)
   end
 
-  def self.remove(submission)
-    submission.remove
-  end
-
   def remove
     if present?
       user_id = @user.id

--- a/lib/custom_wizard/submission.rb
+++ b/lib/custom_wizard/submission.rb
@@ -98,18 +98,18 @@ class CustomWizard::Submission
   end
 
   def self.remove(submission)
-    if submission.present?
-      user_id = submission.user.id
-      wizard_id = submission.wizard.id
-      submission_id = submission.id
+    submission.remove
+  end
+
+  def remove
+    if present?
+      user_id = @user.id
+      wizard_id = @wizard.id
+      submission_id = @id
       data = PluginStore.get("#{wizard_id}_#{KEY}", user_id)
       data.delete_if { |sub| sub["id"] == submission_id }
       PluginStore.set("#{wizard_id}_#{KEY}", user_id, data)
     end
-  end
-
-  def remove
-    self.class.remove(self)
   end
 
   def self.cleanup_incomplete_submissions(wizard)

--- a/lib/custom_wizard/wizard.rb
+++ b/lib/custom_wizard/wizard.rb
@@ -286,15 +286,11 @@ class CustomWizard::Wizard
     end
   end
 
-  def cleanup!
+  def final_cleanup!
     if id == user.custom_fields['redirect_to_wizard']
       user.custom_fields.delete('redirect_to_wizard')
       user.save_custom_fields(true)
     end
-  end
-
-  def final_cleanup!
-    cleanup!
 
     if current_submission.present?
       current_submission.submitted_at = Time.now.iso8601

--- a/lib/custom_wizard/wizard.rb
+++ b/lib/custom_wizard/wizard.rb
@@ -286,14 +286,6 @@ class CustomWizard::Wizard
     end
   end
 
-  def reset_user_progress!
-    UserHistory.where(
-      action: UserHistory.actions[:custom_wizard_step],
-      acting_user_id: user.id,
-      context: id
-    ).destroy_all
-  end
-
   def final_cleanup!
     if id == user.custom_fields['redirect_to_wizard']
       user.custom_fields.delete('redirect_to_wizard')

--- a/lib/custom_wizard/wizard.rb
+++ b/lib/custom_wizard/wizard.rb
@@ -286,6 +286,14 @@ class CustomWizard::Wizard
     end
   end
 
+  def reset_user_progress!
+    UserHistory.where(
+      action: UserHistory.actions[:custom_wizard_step],
+      acting_user_id: user.id,
+      context: id
+    ).destroy_all
+  end
+
   def final_cleanup!
     if id == user.custom_fields['redirect_to_wizard']
       user.custom_fields.delete('redirect_to_wizard')

--- a/lib/custom_wizard/wizard.rb
+++ b/lib/custom_wizard/wizard.rb
@@ -286,11 +286,15 @@ class CustomWizard::Wizard
     end
   end
 
-  def final_cleanup!
+  def cleanup!
     if id == user.custom_fields['redirect_to_wizard']
       user.custom_fields.delete('redirect_to_wizard')
       user.save_custom_fields(true)
     end
+  end
+
+  def final_cleanup!
+    cleanup!
 
     if current_submission.present?
       current_submission.submitted_at = Time.now.iso8601

--- a/spec/requests/custom_wizard/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/wizard_controller_spec.rb
@@ -50,52 +50,55 @@ describe CustomWizard::WizardController do
     expect(response.parsed_body["error"]).to eq("We couldn't find a wizard at that address.")
   end
 
-  it 'skips a wizard if user is allowed to skip' do
-    put '/w/super-mega-fun-wizard/skip.json'
-    expect(response.status).to eq(200)
-  end
+  context 'when user skips the wizard' do
 
-  it 'lets user skip if user cant access wizard' do
-    @template["permitted"] = permitted_json["permitted"]
-    CustomWizard::Template.save(@template, skip_jobs: true)
+    it 'skips a wizard if user is allowed to skip' do
+      put '/w/super-mega-fun-wizard/skip.json'
+      expect(response.status).to eq(200)
+    end
 
-    put '/w/super-mega-fun-wizard/skip.json'
-    expect(response.status).to eq(200)
-  end
+    it 'lets user skip if user cant access wizard' do
+      @template["permitted"] = permitted_json["permitted"]
+      CustomWizard::Template.save(@template, skip_jobs: true)
 
-  it 'returns a no skip message if user is not allowed to skip' do
-    @template['required'] = 'true'
-    CustomWizard::Template.save(@template)
-    put '/w/super-mega-fun-wizard/skip.json'
-    expect(response.parsed_body['error']).to eq("Wizard can't be skipped")
-  end
+      put '/w/super-mega-fun-wizard/skip.json'
+      expect(response.status).to eq(200)
+    end
 
-  it 'skip response contains a redirect_to if in users submissions' do
-    @wizard = CustomWizard::Wizard.create(@template["id"], user)
-    CustomWizard::Submission.new(@wizard, redirect_to: "/t/2").save
-    put '/w/super-mega-fun-wizard/skip.json'
-    expect(response.parsed_body['redirect_to']).to eq('/t/2')
-  end
+    it 'returns a no skip message if user is not allowed to skip' do
+      @template['required'] = 'true'
+      CustomWizard::Template.save(@template)
+      put '/w/super-mega-fun-wizard/skip.json'
+      expect(response.parsed_body['error']).to eq("Wizard can't be skipped")
+    end
 
-  it "deletes the submission if user has filled up some data" do
-    @wizard = CustomWizard::Wizard.create(@template["id"], user)
-    CustomWizard::Submission.new(@wizard, step_1_field_1: "Hello World").save
-    current_submission = @wizard.current_submission
-    put '/w/super-mega-fun-wizard/skip.json'
-    list = CustomWizard::Submission.list(@wizard)
+    it 'skip response contains a redirect_to if in users submissions' do
+      @wizard = CustomWizard::Wizard.create(@template["id"], user)
+      CustomWizard::Submission.new(@wizard, redirect_to: "/t/2").save
+      put '/w/super-mega-fun-wizard/skip.json'
+      expect(response.parsed_body['redirect_to']).to eq('/t/2')
+    end
 
-    expect(list.any? { |submission| submission.id == current_submission.id }).to eq(false)
-  end
+    it "deletes the submission if user has filled up some data" do
+      @wizard = CustomWizard::Wizard.create(@template["id"], user)
+      CustomWizard::Submission.new(@wizard, step_1_field_1: "Hello World").save
+      current_submission = @wizard.current_submission
+      put '/w/super-mega-fun-wizard/skip.json'
+      list = CustomWizard::Submission.list(@wizard)
 
-  it "starts from the first step if user visits after skipping the wizard" do
-    put '/w/super-mega-fun-wizard/steps/step_1.json', params: {
-      fields: {
-        step_1_field_1: "Text input"
+      expect(list.any? { |submission| submission.id == current_submission.id }).to eq(false)
+    end
+
+    it "starts from the first step if user visits after skipping the wizard" do
+      put '/w/super-mega-fun-wizard/steps/step_1.json', params: {
+        fields: {
+          step_1_field_1: "Text input"
+        }
       }
-    }
-    put '/w/super-mega-fun-wizard/skip.json'
-    get '/w/super-mega-fun-wizard.json'
+      put '/w/super-mega-fun-wizard/skip.json'
+      get '/w/super-mega-fun-wizard.json'
 
-    expect(response.parsed_body["start"]).to eq('step_1')
+      expect(response.parsed_body["start"]).to eq('step_1')
+    end
   end
 end

--- a/spec/requests/custom_wizard/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/wizard_controller_spec.rb
@@ -86,4 +86,16 @@ describe CustomWizard::WizardController do
 
     expect(list.any? { |submission| submission.id == current_submission.id }).to eq(false)
   end
+
+  it "starts from the first step if user visits after skipping the wizard" do
+    put '/w/super-mega-fun-wizard/steps/step_1.json', params: {
+      fields: {
+        step_1_field_1: "Text input"
+      }
+    }
+    put '/w/super-mega-fun-wizard/skip.json'
+    get '/w/super-mega-fun-wizard.json'
+
+    expect(response.parsed_body["start"]).to eq('step_1')
+  end
 end

--- a/spec/requests/custom_wizard/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/wizard_controller_spec.rb
@@ -76,4 +76,14 @@ describe CustomWizard::WizardController do
     put '/w/super-mega-fun-wizard/skip.json'
     expect(response.parsed_body['redirect_to']).to eq('/t/2')
   end
+
+  it "deletes the submission if user has filled up some data" do
+    @wizard = CustomWizard::Wizard.create(@template["id"], user)
+    CustomWizard::Submission.new(@wizard, step_1_field_1: "Hello World").save
+    current_submission = @wizard.current_submission
+    put '/w/super-mega-fun-wizard/skip.json'
+    list = CustomWizard::Submission.list(@wizard)
+
+    expect(list.any? { |submission| submission.id == current_submission.id }).to eq(false)
+  end
 end


### PR DESCRIPTION
Changes :
-  removes current submission if user skips the wizard.
- resets step progress for the user so that the wizard starts from the first step when user visits next.