### PR TITLE
FIX: disable string caching in `Oj` gem while running specs

### DIFF
--- a/spec/plugin_helper.rb
+++ b/spec/plugin_helper.rb
@@ -11,4 +11,7 @@ if ENV['SIMPLECOV']
   end
 end
 
+require 'oj'
+Oj.default_options = Oj.default_options.merge(cache_str: -1)
+
 require 'rails_helper'


### PR DESCRIPTION
@angusmcleod 

Explaination:
This PR addresses the spec failures we see in [this workflow run](https://github.com/paviliondev/discourse-custom-wizard/runs/3290606534). The reason for failure is, our fixture json contains small strings like`"1"` etc. 

[This discourse commit](https://github.com/discourse/discourse/commit/7ecd0da109e6eae87b680fb0741f4c19ab8ac08a ) bumps the version of Oj gem which looks safe and harmless.

The Oj gem is used in discourse as a default for parsing json. But that particular version introduces major changes including  **String Caching** for short strings while parsing json to improve overall performance.  In order to cache short strings, it `freeze`s them and hence they become immutable.

When any of those strings are passed to our `Mapper`'s `interpolate` method, it tries to mutate those strings which raises an exception and hence many specs fail.

This PR simply turns off the **String Caching** feature of `Oj` gem while running specs.

Relevant github issue: https://github.com/ohler55/oj/issues/691