### PR TITLE
DEV: split log messages

### DIFF
--- a/db/migrate/20210806135416_split_custom_wizard_log_fields.rb
+++ b/db/migrate/20210806135416_split_custom_wizard_log_fields.rb
@@ -1,0 +1,70 @@
+class SplitCustomWizardLogFields < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up do
+          # separate wizard/action/user into their own keys
+
+          wizard_logs = PluginStoreRow.where("
+            plugin_name = 'custom_wizard_log' 
+          ")
+
+          if wizard_logs.exists?
+            wizard_logs.each do |row|
+              begin
+                log_json = JSON.parse(row.value)
+              rescue TypeError, JSON::ParserError
+                next
+              end
+
+              # first three keys are wizard/action/user
+
+              if log_json.key?('message')
+                attr_strs = log_json['message'].split('; ', 4)
+
+                log_json['message'] = attr_strs.pop
+
+                attr_strs.each do |attr_str|
+                  key, value = attr_str.split(': ')
+                  log_json[key] = value
+                end
+
+                row.value = log_json.to_json
+                row.save
+
+              end
+            end
+          end
+      end
+      dir.down do
+        wizard_logs = PluginStoreRow.where("
+          plugin_name = 'custom_wizard_log' 
+        ")
+
+        if wizard_logs.exists?
+          wizard_logs.each do |row|
+            begin
+              log_json = JSON.parse(row.value)
+            rescue TypeError, JSON::ParserError
+              next
+            end
+
+            # concatenate wizard/action/user to start of message
+            prefixes = log_json.extract!('wizard', 'action', 'user')
+
+            message_prefix = prefixes.map{|k,v| "#{k}: #{v}"}.join('; ')
+
+            if log_json.key?('message')
+              log_json['message'] = "#{message_prefix}; #{log_json['message']}"
+            else
+              log_json['message'] = message_prefix
+            end
+
+            row.value = log_json.to_json
+            row.save
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210806135416_split_custom_wizard_log_fields.rb
+++ b/db/migrate/20210806135416_split_custom_wizard_log_fields.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
 class SplitCustomWizardLogFields < ActiveRecord::Migration[6.1]
   def change
     reversible do |dir|
       dir.up do
-          # separate wizard/action/user into their own keys
+        # separate wizard/action/user into their own keys
 
-          wizard_logs = PluginStoreRow.where("
-            plugin_name = 'custom_wizard_log' 
+        wizard_logs = PluginStoreRow.where("
+            plugin_name = 'custom_wizard_log'
           ")
 
           if wizard_logs.exists?
@@ -16,8 +17,7 @@ class SplitCustomWizardLogFields < ActiveRecord::Migration[6.1]
                 next
               end
 
-
-              if log_json.key?('message') and log_json['message'].is_a? String
+              if log_json.key?('message') && log_json['message'].is_a?(String)
 
                 attr_strs = []
 
@@ -28,7 +28,7 @@ class SplitCustomWizardLogFields < ActiveRecord::Migration[6.1]
 
                 attr_strs.each do |attr_str|
                   if attr_str.is_a? String
-                    attr_str.gsub!(/[;]/ ,"")
+                    attr_str.gsub!(/[;]/ , "")
                     key, value = attr_str.split(': ')
                     value.strip! if value
                     log_json[key] = value ? value : ''
@@ -44,7 +44,7 @@ class SplitCustomWizardLogFields < ActiveRecord::Migration[6.1]
       end
       dir.down do
         wizard_logs = PluginStoreRow.where("
-          plugin_name = 'custom_wizard_log' 
+          plugin_name = 'custom_wizard_log'
         ")
 
         if wizard_logs.exists?
@@ -58,7 +58,7 @@ class SplitCustomWizardLogFields < ActiveRecord::Migration[6.1]
             # concatenate wizard/action/user to start of message
             prefixes = log_json.extract!('wizard', 'action', 'user')
 
-            message_prefix = prefixes.map{|k,v| "#{k}: #{v}"}.join('; ')
+            message_prefix = prefixes.map { |k, v| "#{k}: #{v}" }.join('; ')
 
             if log_json.key?('message')
               log_json['message'] = "#{message_prefix}; #{log_json['message']}"

--- a/lib/custom_wizard/action.rb
+++ b/lib/custom_wizard/action.rb
@@ -742,14 +742,11 @@ class CustomWizard::Action
   end
 
   def save_log
-    log = "wizard: #{@wizard.id}; action: #{action['type']}; user: #{user.username}"
-
-    if @log.any?
-      @log.each do |item|
-        log += "; #{item.to_s}"
-      end
-    end
-
-    CustomWizard::Log.create(log)
+    CustomWizard::Log.create(
+      @wizard.id,
+      action['type'],
+      user.username,
+      @log.join('; ')
+    )
   end
 end

--- a/lib/custom_wizard/log.rb
+++ b/lib/custom_wizard/log.rb
@@ -2,22 +2,28 @@
 class CustomWizard::Log
   include ActiveModel::Serialization
 
-  attr_accessor :message, :date
+  attr_accessor :date, :wizard, :action, :user, :message
 
   PAGE_LIMIT = 100
 
   def initialize(attrs)
-    @message = attrs['message']
     @date = attrs['date']
+    @wizard = attrs['wizard']
+    @action = attrs['action']
+    @user = attrs['user']
+    @message = attrs['message']
   end
 
-  def self.create(message)
+  def self.create(wizard, action, user, message)
     log_id = SecureRandom.hex(12)
 
     PluginStore.set('custom_wizard_log',
       log_id.to_s,
       {
         date: Time.now,
+        wizard: wizard,
+        action: action,
+        user: user,
         message: message
       }
     )

--- a/serializers/custom_wizard/log_serializer.rb
+++ b/serializers/custom_wizard/log_serializer.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class CustomWizard::LogSerializer < ApplicationSerializer
-  attributes :message, :date
+  attributes :date, :wizard, :action, :user, :message
 end

--- a/spec/components/custom_wizard/log_spec.rb
+++ b/spec/components/custom_wizard/log_spec.rb
@@ -3,9 +3,9 @@ require_relative '../../plugin_helper'
 
 describe CustomWizard::Log do
   before do
-    CustomWizard::Log.create("First log message")
-    CustomWizard::Log.create("Second log message")
-    CustomWizard::Log.create("Third log message")
+    CustomWizard::Log.create('first-test-wizard', 'perform_first_action', 'first_test_user', 'First log message')
+    CustomWizard::Log.create('second-test-wizard', 'perform_second_action', 'second_test_user', 'Second log message')
+    CustomWizard::Log.create('third-test-wizard', 'perform_third_action', 'third_test_user', 'Third log message')
   end
 
   it "creates logs" do

--- a/spec/requests/custom_wizard/admin/logs_controller_spec.rb
+++ b/spec/requests/custom_wizard/admin/logs_controller_spec.rb
@@ -5,9 +5,9 @@ describe CustomWizard::AdminLogsController do
   fab!(:admin_user) { Fabricate(:user, admin: true) }
 
   before do
-    CustomWizard::Log.create("First log message")
-    CustomWizard::Log.create("Second log message")
-    CustomWizard::Log.create("Third log message")
+    CustomWizard::Log.create('first-test-wizard', 'perform_first_action', 'first_test_user', 'First log message')
+    CustomWizard::Log.create('second-test-wizard', 'perform_second_action', 'second_test_user', 'Second log message')
+    CustomWizard::Log.create('third-test-wizard', 'perform_third_action', 'third_test_user', 'Third log message')
     sign_in(admin_user)
   end
 

--- a/spec/serializers/custom_wizard/log_serializer_spec.rb
+++ b/spec/serializers/custom_wizard/log_serializer_spec.rb
@@ -6,14 +6,17 @@ describe CustomWizard::LogSerializer do
   fab!(:user) { Fabricate(:user) }
 
   it 'should return log attributes' do
-    CustomWizard::Log.create("First log message")
-    CustomWizard::Log.create("Second log message")
+    CustomWizard::Log.create('first-test-wizard', 'perform_first_action', 'first_test_user', 'First log message')
+    CustomWizard::Log.create('second-test-wizard', 'perform_second_action', 'second_test_user', 'Second log message')
 
     json_array = ActiveModel::ArraySerializer.new(
       CustomWizard::Log.list(0),
       each_serializer: CustomWizard::LogSerializer
     ).as_json
     expect(json_array.length).to eq(2)
+    expect(json_array[0][:wizard]).to eq("second-test-wizard")
+    expect(json_array[0][:action]).to eq("perform_second_action")
+    expect(json_array[0][:user]).to eq("second_test_user")
     expect(json_array[0][:message]).to eq("Second log message")
   end
 end


### PR DESCRIPTION
Split out the wizard, user and action in the message field for custom wizard logs into their own fields.

Includes data migration and updates to saving logs. This has an incidental effect on the log page, which will show the shortened message.