### PR TITLE
FIX: field validation was not working in backend

### DIFF
--- a/lib/custom_wizard/validators/template.rb
+++ b/lib/custom_wizard/validators/template.rb
@@ -18,8 +18,8 @@ class CustomWizard::TemplateValidator
     data[:steps].each do |step|
       check_required(step, :step)
 
-      if data[:fields].present?
-        data[:fields].each do |field|
+      if step[:fields].present?
+        step[:fields].each do |field|
           check_required(field, :field)
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Create custom wizards
-# version: 1.15.5
+# version: 1.15.6
 # authors: Angus McLeod
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact emails: angus@thepavilion.io

--- a/spec/components/custom_wizard/template_validator_spec.rb
+++ b/spec/components/custom_wizard/template_validator_spec.rb
@@ -45,4 +45,37 @@ describe CustomWizard::TemplateValidator do
       CustomWizard::TemplateValidator.new(template).perform
     ).to eq(false)
   end
+
+  context "steps" do
+    CustomWizard::TemplateValidator.required[:step].each do |attribute|
+      it "invalidates if \"#{attribute.to_s}\" is not present" do
+        template[:steps][0][attribute] = nil
+        expect(
+          CustomWizard::TemplateValidator.new(template).perform
+        ).to eq(false)
+      end
+    end
+  end
+
+  context "fields" do
+    CustomWizard::TemplateValidator.required[:field].each do |attribute|
+      it "invalidates if \"#{attribute.to_s}\" is not present" do
+        template[:steps][0][:fields][0][attribute] = nil
+        expect(
+          CustomWizard::TemplateValidator.new(template).perform
+        ).to eq(false)
+      end
+    end
+  end
+
+  context "actions" do
+    CustomWizard::TemplateValidator.required[:action].each do |attribute|
+      it "invalidates if \"#{attribute.to_s}\" is not present" do
+        template[:actions][0][attribute] = nil
+        expect(
+          CustomWizard::TemplateValidator.new(template).perform
+        ).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
@angusmcleod 
- Our template validator isn't validating the fields correctly in the backend. The fields are in `step[:fields]`.
- The reason why field validation still works is, we're relying on the frontend code for validating fields and sending frontend errors to backend. Here's the responsible code. https://github.com/paviliondev/discourse-custom-wizard/blob/757b382345c739c9a65fc5888ce322277d99994c/assets/javascripts/discourse/models/custom-wizard.js.es6#L14
- I think in the future, we should tweak the code such that we're only validating on the server. 

- Writing specs for this one now.