### PR TITLE
DEV: Use Uppy for wizard-field-upload

### DIFF
--- a/assets/javascripts/wizard/templates/components/wizard-field-upload.hbs
+++ b/assets/javascripts/wizard/templates/components/wizard-field-upload.hbs
@@ -6,7 +6,7 @@
     {{d-icon "upload"}}
   {{/if}}
 
-  <input disabled={{uploading}} type="file" accept={{field.file_types}} style="visibility: hidden; position: absolute;" >
+  <input class="wizard-hidden-upload-field" disabled={{uploading}} type="file" accept={{field.file_types}} style="visibility: hidden; position: absolute;" >
 </label>
 
 {{#if field.value}}


### PR DESCRIPTION
We just stopped using jQuery file upload in the core wizard
upload field in https://github.com/discourse/discourse/commit/18a209bd0dea9a77953d7f405ed3e37a7fb52b90.
This is part of the broader strategy to remove jQuery file upload.
This commit changes the wizard-field-upload component to
use Uppy instead.