### PR TITLE
FIX: Use uppy-image-uploader instead of image-uploader

### DIFF
--- a/assets/javascripts/discourse/templates/components/wizard-custom-field.hbs
+++ b/assets/javascripts/discourse/templates/components/wizard-custom-field.hbs
@@ -40,12 +40,13 @@
     <label>{{i18n "admin.wizard.field.image"}}</label>
   </div>
   <div class="setting-value">
-    {{image-uploader
+    {{uppy-image-uploader
       imageUrl=field.image
       onUploadDone=(action "imageUploadDone")
       onUploadDeleted=(action "imageUploadDeleted")
       type="wizard-step"
-      class="no-repeat contain-image"}}
+      class="no-repeat contain-image"
+      id=(concat "wizard-field-" field.id "-image-upload")}}
   </div>
 </div>
 

--- a/assets/javascripts/discourse/templates/components/wizard-custom-step.hbs
+++ b/assets/javascripts/discourse/templates/components/wizard-custom-step.hbs
@@ -14,12 +14,13 @@
     <label>{{i18n "admin.wizard.step.banner"}}</label>
   </div>
   <div class="setting-value">
-    {{image-uploader
+    {{uppy-image-uploader
       imageUrl=step.banner
       onUploadDone=(action "bannerUploadDone")
       onUploadDeleted=(action "bannerUploadDeleted")
       type="wizard-banner"
-      class="no-repeat contain-image"}}
+      class="no-repeat contain-image"
+      id=(concat "wizard-step-" step.id "-banner-upload")}}
   </div>
 </div>
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Create custom wizards
-# version: 1.16.1
+# version: 1.16.2
 # authors: Angus McLeod
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact emails: angus@thepavilion.io


### PR DESCRIPTION
The image-uploader component is deprecated and will
be removed shortly in Discourse core. The new component
is functionally equivalent.