### PR TITLE
DEV: Replace `{{user-selector}}` with `{{email-group-user-chooser}}`

### DIFF
--- a/assets/javascripts/discourse/components/wizard-mapper-selector.js.es6
+++ b/assets/javascripts/discourse/components/wizard-mapper-selector.js.es6
@@ -377,7 +377,7 @@ export default Component.extend({
       this.changeValue(event.target.value);
     },
 
-    changeUserValue(previousValue, value) {
+    changeUserValue(value) {
       this.changeValue(value);
     },
   },

--- a/assets/javascripts/discourse/templates/components/wizard-mapper-selector.hbs
+++ b/assets/javascripts/discourse/templates/components/wizard-mapper-selector.hbs
@@ -66,11 +66,13 @@
   {{/if}}
 
   {{#if showUser}}
-    {{user-selector
-      includeMessageableGroups="true"
+    {{email-group-user-chooser
       placeholderKey=placeholderKey
-      usernames=value
+      value=value
       autocomplete="discourse"
-      onChangeCallback=(action "changeUserValue")}}
+      onChange=(action "changeUserValue")
+      options=(hash
+        includeMessageableGroups="true"
+      )}}
   {{/if}}
 </div>

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Create custom wizards
-# version: 1.22.0
+# version: 1.22.1
 # authors: Angus McLeod
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact emails: angus@pavilion.tech


### PR DESCRIPTION
`{{user-selector}}` has been deprecated since February 2021 and is about to be removed https://github.com/discourse/discourse/commit/293fd1f743b1c8165e1cd06b1169134197a231f7. `{{email-group-user-chooser}}` is the new replacement and this PR migrates the plugin to use this new component. Screenshot of this change in action:

![image](https://user-images.githubusercontent.com/17474474/181797742-23b695e1-7b62-4b58-83c1-16eda83a6b05.png)
