### PR TITLE
Allow upload button in wizard composer when in mobile view

### DIFF
--- a/assets/javascripts/discourse/components/custom-wizard-composer-editor.js.es6
+++ b/assets/javascripts/discourse/components/custom-wizard-composer-editor.js.es6
@@ -149,7 +149,7 @@ export default ComposerEditor.extend({
     extraButtons(toolbar) {
       const component = this;
 
-      if (this.allowUpload && this.uploadIcon && !this.site.mobileView) {
+      if (this.allowUpload && this.uploadIcon) {
         toolbar.addButton({
           id: "upload",
           group: "insertions",

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.1.0
+# version: 2.1.1
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
https://discourse.pluginmanager.org/t/image-upload-button-missing-in-composer-on-mobile-view/584