### PR TITLE
Patch for wizard URL path to take account of subdirectory base URL.

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
@@ -37,10 +37,7 @@ export default Controller.extend({
   @discourseComputed("wizard.id")
   wizardUrl(wizardId) {
     let baseUrl = window.location.href.split("/admin");
-    if (baseUrl.length > 1) {
-      return baseUrl[0] + "/w/" + dasherize(wizardId);
-    }
-    return window.location.origin + "/w/" + dasherize(wizardId);
+    return baseUrl[0] + "/w/" + dasherize(wizardId);
   },
 
   @discourseComputed("wizard.after_time_scheduled")

--- a/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
@@ -39,7 +39,7 @@ export default Controller.extend({
     let baseUrl = (window.location.href).split('/admin');
     if (baseUrl.length > 1) {
       return baseUrl[0] + "/w/" + dasherize(wizardId);
-    } 
+    }
     return window.location.origin + "/w/" + dasherize(wizardId);
   },
 

--- a/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
@@ -36,6 +36,10 @@ export default Controller.extend({
 
   @discourseComputed("wizard.id")
   wizardUrl(wizardId) {
+    let baseUrl = (window.location.href).split('/admin');
+    if (baseUrl.length > 1) {
+      return baseUrl[0] + "/w/" + dasherize(wizardId);
+    } 
     return window.location.origin + "/w/" + dasherize(wizardId);
   },
 

--- a/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-wizards-wizard-show.js.es6
@@ -36,7 +36,7 @@ export default Controller.extend({
 
   @discourseComputed("wizard.id")
   wizardUrl(wizardId) {
-    let baseUrl = (window.location.href).split('/admin');
+    let baseUrl = window.location.href.split("/admin");
     if (baseUrl.length > 1) {
       return baseUrl[0] + "/w/" + dasherize(wizardId);
     }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.1.1
+# version: 2.1.2
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
A patch for the preview Wizard URL path (in admin view) to take account of Discourse deployments with subdirectory base URL i.e. `www.discourse.com/foo/bar`. 

Currently it will present the URL only on the top level domain i.e. `www.discourse.com/w/1234` where it should have included the subdirectories. i.e. `www.discourse.com/foo/bar/w/1234`

