### PR TITLE
Fix category selector overflow on mobile

### DIFF
--- a/assets/stylesheets/common/wizard/mobile.scss
+++ b/assets/stylesheets/common/wizard/mobile.scss
@@ -33,4 +33,9 @@ body.custom-wizard {
     margin-bottom: 20px;
     width: 100%;
   }
+  
+  .wizard-category-selector {
+    width: 100%;
+    max-width: 500px;
+}
 }


### PR DESCRIPTION
The category selector tends to overflow on mobile due to width being declared as 500px, This commit changes that to max-width and adding width: 100% to make it scale to screen size.