### PR TITLE
FIX: failing log spec

### DIFF
--- a/lib/custom_wizard/log.rb
+++ b/lib/custom_wizard/log.rb
@@ -15,13 +15,13 @@ class CustomWizard::Log
     @username = attrs['username']
   end
 
-  def self.create(wizard_id, action, username, message)
+  def self.create(wizard_id, action, username, message, date = Time.now)
     log_id = SecureRandom.hex(12)
 
     PluginStore.set('custom_wizard_log',
       log_id.to_s,
       {
-        date: Time.now,
+        date: date,
         wizard_id: wizard_id,
         action: action,
         username: username,

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.3.1
+# version: 2.3.2
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech

--- a/spec/serializers/custom_wizard/log_serializer_spec.rb
+++ b/spec/serializers/custom_wizard/log_serializer_spec.rb
@@ -4,7 +4,7 @@ describe CustomWizard::LogSerializer do
   fab!(:user) { Fabricate(:user) }
 
   it 'should return log attributes' do
-    CustomWizard::Log.create('first-test-wizard', 'perform_first_action', 'first_test_user', 'First log message')
+    CustomWizard::Log.create('first-test-wizard', 'perform_first_action', 'first_test_user', 'First log message', 1.day.ago)
     CustomWizard::Log.create('second-test-wizard', 'perform_second_action', 'second_test_user', 'Second log message')
 
     json_array = ActiveModel::ArraySerializer.new(


### PR DESCRIPTION
* Add the ability to specify a date for the log (default Now) so that order is "testable" in a spec.