### PR TITLE
FIX: direct after start time default for new wizard

### DIFF
--- a/assets/javascripts/discourse/controllers/next-session-scheduled.js.es6
+++ b/assets/javascripts/discourse/controllers/next-session-scheduled.js.es6
@@ -5,7 +5,10 @@ export default Controller.extend({
   title: "admin.wizard.after_time_modal.title",
 
   setup() {
-    this.set("bufferedDateTime", moment(this.model.dateTime));
+    this.set(
+      "bufferedDateTime",
+      this.model.dateTime ? moment(this.model.dateTime) : moment(Date.now())
+    );
   },
 
   @discourseComputed("bufferedDateTime")

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.4.13
+# version: 2.4.14
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Juan Marcos Gutierrez Ramos
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech

--- a/test/javascripts/acceptance/admin-wizards-unsuscribed-test.js
+++ b/test/javascripts/acceptance/admin-wizards-unsuscribed-test.js
@@ -94,7 +94,7 @@ acceptance("Admin | Custom Wizard Unsuscribed", function (needs) {
     assert.ok(
       exists(".d-date-time-input .d-time-input span.name"),
       "a time selector is shown"
-    )
+    );
     let timeText = query(
       ".d-date-time-input .d-time-input span.name"
     ).innerText;

--- a/test/javascripts/acceptance/admin-wizards-unsuscribed-test.js
+++ b/test/javascripts/acceptance/admin-wizards-unsuscribed-test.js
@@ -90,6 +90,16 @@ acceptance("Admin | Custom Wizard Unsuscribed", function (needs) {
     );
     const wizardLink = find("div.wizard-url a");
     assert.equal(wizardLink.length, 1, "Wizard link was created");
+    await click(".btn-after-time");
+    assert.ok(
+      exists(".d-date-time-input .d-time-input span.name"),
+      "a time selector is shown"
+    )
+    let timeText = query(
+      ".d-date-time-input .d-time-input span.name"
+    ).innerText;
+    const regex = /\d\d\:\d\d/;
+    assert.ok(regex.test(timeText));
     assert.equal(
       $.trim($("a[title='Subscribe to use these features']").text()),
       "Not Subscribed",


### PR DESCRIPTION
* Currently when you create a new wizard the time shows NaN.