### PR TITLE
FIX: Remove category custom field on wizard delete (Take Two)

### DIFF
--- a/lib/custom_wizard/template.rb
+++ b/lib/custom_wizard/template.rb
@@ -64,7 +64,7 @@ class CustomWizard::Template
       ensure_wizard_upload_references!(wizard_id)
       PluginStore.remove(CustomWizard::PLUGIN_NAME, wizard.id)
       clear_user_wizard_redirect(wizard_id, after_time: !!wizard.after_time)
-      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize.underscore)
+      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize.underscore.downcase)
       related_custom_fields.destroy_all
     end
 

--- a/lib/custom_wizard/template.rb
+++ b/lib/custom_wizard/template.rb
@@ -64,7 +64,7 @@ class CustomWizard::Template
       ensure_wizard_upload_references!(wizard_id)
       PluginStore.remove(CustomWizard::PLUGIN_NAME, wizard.id)
       clear_user_wizard_redirect(wizard_id, after_time: !!wizard.after_time)
-      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize.underscore.downcase)
+      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize.underscore)
       related_custom_fields.destroy_all
     end
 

--- a/lib/custom_wizard/template.rb
+++ b/lib/custom_wizard/template.rb
@@ -64,7 +64,7 @@ class CustomWizard::Template
       ensure_wizard_upload_references!(wizard_id)
       PluginStore.remove(CustomWizard::PLUGIN_NAME, wizard.id)
       clear_user_wizard_redirect(wizard_id, after_time: !!wizard.after_time)
-      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name)
+      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize.underscore)
       related_custom_fields.destroy_all
     end
 

--- a/lib/custom_wizard/template.rb
+++ b/lib/custom_wizard/template.rb
@@ -64,7 +64,7 @@ class CustomWizard::Template
       ensure_wizard_upload_references!(wizard_id)
       PluginStore.remove(CustomWizard::PLUGIN_NAME, wizard.id)
       clear_user_wizard_redirect(wizard_id, after_time: !!wizard.after_time)
-      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize.underscore)
+      related_custom_fields = CategoryCustomField.where(name: 'create_topic_wizard', value: wizard.name.parameterize(separator: "_"))
       related_custom_fields.destroy_all
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.4.14
+# version: 2.4.15
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Juan Marcos Gutierrez Ramos
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech

--- a/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
@@ -5,7 +5,7 @@ describe CustomWizard::AdminWizardController do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   let(:template) { get_wizard_fixture("wizard") }
-  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize.underscore }) }
+  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize.underscore.downcase }) }
 
   before do
     CustomWizard::Template.save(template, skip_jobs: true)
@@ -41,11 +41,11 @@ describe CustomWizard::AdminWizardController do
   end
 
   it "removes wizard templates whilst making sure create_topic_wizard settings for that wizard are removed from Categories" do
-    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).not_to eq(nil)
+    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize.underscore.downcase)).not_to eq(nil)
     delete "/admin/wizards/wizard/#{template['id']}.json"
     expect(response.status).to eq(200)
     expect(CustomWizard::Template.exists?(template['id'])).to eq(false)
-    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).to eq(nil)
+    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize.underscore.downcase)).to eq(nil)
   end
 
   it "saves wizard templates" do

--- a/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
@@ -5,7 +5,7 @@ describe CustomWizard::AdminWizardController do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   let(:template) { get_wizard_fixture("wizard") }
-  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize.underscore }) }
+  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize(separator: "_") }) }
 
   before do
     CustomWizard::Template.save(template, skip_jobs: true)
@@ -41,11 +41,11 @@ describe CustomWizard::AdminWizardController do
   end
 
   it "removes wizard templates whilst making sure create_topic_wizard settings for that wizard are removed from Categories" do
-    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).not_to eq(nil)
+    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize(separator: "_"))).not_to eq(nil)
     delete "/admin/wizards/wizard/#{template['id']}.json"
     expect(response.status).to eq(200)
     expect(CustomWizard::Template.exists?(template['id'])).to eq(false)
-    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).to eq(nil)
+    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize(separator: "_"))).to eq(nil)
   end
 
   it "saves wizard templates" do

--- a/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
@@ -5,7 +5,7 @@ describe CustomWizard::AdminWizardController do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   let(:template) { get_wizard_fixture("wizard") }
-  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize.underscore.downcase }) }
+  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize.underscore }) }
 
   before do
     CustomWizard::Template.save(template, skip_jobs: true)
@@ -41,11 +41,11 @@ describe CustomWizard::AdminWizardController do
   end
 
   it "removes wizard templates whilst making sure create_topic_wizard settings for that wizard are removed from Categories" do
-    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize.underscore.downcase)).not_to eq(nil)
+    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).not_to eq(nil)
     delete "/admin/wizards/wizard/#{template['id']}.json"
     expect(response.status).to eq(200)
     expect(CustomWizard::Template.exists?(template['id'])).to eq(false)
-    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize.underscore.downcase)).to eq(nil)
+    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).to eq(nil)
   end
 
   it "saves wizard templates" do

--- a/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
+++ b/spec/requests/custom_wizard/admin/wizard_controller_spec.rb
@@ -5,7 +5,7 @@ describe CustomWizard::AdminWizardController do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   let(:template) { get_wizard_fixture("wizard") }
-  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'] }) }
+  let(:category) { Fabricate(:category, custom_fields: { create_topic_wizard: template['name'].parameterize.underscore }) }
 
   before do
     CustomWizard::Template.save(template, skip_jobs: true)
@@ -41,11 +41,11 @@ describe CustomWizard::AdminWizardController do
   end
 
   it "removes wizard templates whilst making sure create_topic_wizard settings for that wizard are removed from Categories" do
-    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'])).not_to eq(nil)
+    expect(CategoryCustomField.find_by(category_id: category.id, name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).not_to eq(nil)
     delete "/admin/wizards/wizard/#{template['id']}.json"
     expect(response.status).to eq(200)
     expect(CustomWizard::Template.exists?(template['id'])).to eq(false)
-    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'])).to eq(nil)
+    expect(CategoryCustomField.find_by(name: 'create_topic_wizard', value: template['name'].parameterize.underscore)).to eq(nil)
   end
 
   it "saves wizard templates" do


### PR DESCRIPTION
* Thought we'd fixed this in prior PR (#255) but it fails with multi word wizard names as they are underscored and down cased.
* Take two: now ensure this works with multi-word named wizard