### PR TITLE
REVERT: Update insert-hyperlink invocation following core change

### DIFF
--- a/assets/javascripts/discourse/components/custom-wizard-composer-editor.js.es6
+++ b/assets/javascripts/discourse/components/custom-wizard-composer-editor.js.es6
@@ -12,14 +12,12 @@ import { alias } from "@ember/object/computed";
 import Site from "discourse/models/site";
 import { uploadIcon } from "discourse/lib/uploads";
 import { dasherize } from "@ember/string";
-import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
-import { inject as service } from "@ember/service";
+import showModal from "discourse/lib/show-modal";
 
 const IMAGE_MARKDOWN_REGEX =
   /!\[(.*?)\|(\d{1,4}x\d{1,4})(,\s*\d{1,3}%)?(.*?)\]\((upload:\/\/.*?)\)(?!(.*`))/g;
 
 export default ComposerEditor.extend({
-  modal: service(),
 
   classNameBindings: ["fieldClass"],
   allowUpload: true,
@@ -200,8 +198,9 @@ export default ComposerEditor.extend({
       if (this._lastSel) {
         linkText = this._lastSel.value;
       }
-      this.modal.show(InsertHyperlink, {
-        model: { linkText, toolbarEvent },
+      showModal("insert-hyperlink").setProperties({
+        linkText,
+        toolbarEvent,
       });
     },
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.4.17
+# version: 2.4.18
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Juan Marcos Gutierrez Ramos
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
👋 Hi all,

This PR reverts a change in the stable branch that caused errors. The update was needed for the main branch but not for stable.

Additionally, we need to update the CI workflow to test the stable branch of this plugin against Discourse's stable branch. I'll work on this change.

Thanks,
Marcos