### PR TITLE
Filter categories for admin staff

### DIFF
--- a/assets/javascripts/discourse/initializers/custom-wizard-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/custom-wizard-edits.js.es6
@@ -87,10 +87,13 @@ export default {
       api.modifyClass("component:category-chooser", {
         categoriesByScope(options = {}) {
           let categories = this._super(options);
-
-          return categories.filter((category) => {
-            return !category.custom_fields?.create_topic_wizard;
-          });
+          const currentUser = this.currentUser;
+          if (!(currentUser && (currentUser.admin || currentUser.staff))) {
+            categories = categories.filter((category) => {
+              return !category.custom_fields?.create_topic_wizard;
+            });
+          }
+          return categories;
         },
       });
     });

--- a/assets/javascripts/discourse/initializers/custom-wizard-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/custom-wizard-edits.js.es6
@@ -88,7 +88,7 @@ export default {
         categoriesByScope(options = {}) {
           let categories = this._super(options);
           const currentUser = this.currentUser;
-          if (!(currentUser && (currentUser.admin || currentUser.staff))) {
+          if (!currentUser?.staff) {
             categories = categories.filter((category) => {
               return !category.custom_fields?.create_topic_wizard;
             });

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.4.25
+# version: 2.4.26
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Juan Marcos Gutierrez Ramos
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech

--- a/test/javascripts/acceptance/category-chooser-initializer-test.js
+++ b/test/javascripts/acceptance/category-chooser-initializer-test.js
@@ -3,8 +3,8 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 
-acceptance("Category Chooser Initializer", function (needs) {
-  needs.user();
+acceptance("Category Chooser Initializer for regular users", function (needs) {
+  needs.user({ staff: false, admin: false, moderator: false });
   needs.settings({
     allow_uncategorized_topics: false,
   });
@@ -45,9 +45,8 @@ acceptance("Category Chooser Initializer", function (needs) {
     ],
   });
 
-  test("does not display category with create_topic_wizard custom field", async function (assert) {
+  test("does not display category with create_topic_wizard for regular users", async function (assert) {
     const categoryChooser = selectKit(".category-chooser");
-
     await visit("/");
     await click("#create-topic");
     await categoryChooser.expand();
@@ -78,5 +77,150 @@ acceptance("Category Chooser Initializer", function (needs) {
       ),
       `Category '${categoryNameWithCustomField}' is not displayed`
     );
+  });
+});
+
+acceptance("Category Chooser Initializer for Admins", function (needs) {
+  needs.user({ admin: true });
+  needs.settings({
+    allow_uncategorized_topics: false,
+  });
+  needs.site({
+    can_tag_topics: true,
+    categories: [
+      {
+        id: 1,
+        name: "General",
+        slug: "general",
+        permission: 1,
+        topic_template: null,
+      },
+      {
+        id: 2,
+        name: "Category with custom field",
+        slug: "category-custom-field",
+        permission: 1,
+        topic_template: "",
+        custom_fields: {
+          create_topic_wizard: "21",
+        },
+      },
+      {
+        id: 3,
+        name: "Category 1",
+        slug: "category-1",
+        permission: 1,
+        topic_template: "",
+      },
+      {
+        id: 4,
+        name: "Category 2",
+        slug: "category-2",
+        permission: 1,
+        topic_template: "",
+      },
+    ],
+  });
+
+  test("displays all categories", async function (assert) {
+    const categoryChooser = selectKit(".category-chooser");
+    await visit("/");
+    await click("#create-topic");
+    await categoryChooser.expand();
+    let categories = Array.from(
+      document.querySelectorAll(".category-chooser .category-row")
+    ).filter((category) => category.getAttribute("data-name")); // Filter elements with a data-name attribute
+    assert.equal(
+      categories.length,
+      4,
+      "Correct number of categories are displayed"
+    );
+    const categoryNames = [
+      "General",
+      "Category 1",
+      "Category 2",
+      "Category with custom field",
+    ];
+
+    categoryNames.forEach((categoryName) => {
+      assert.ok(
+        categories.some(
+          (category) => category.getAttribute("data-name") === categoryName
+        ),
+        `Category '${categoryName}' is displayed`
+      );
+    });
+  });
+});
+acceptance("Category Chooser Initializer for Staff", function (needs) {
+  needs.user({ staff: true });
+  needs.settings({
+    allow_uncategorized_topics: false,
+  });
+  needs.site({
+    can_tag_topics: true,
+    categories: [
+      {
+        id: 1,
+        name: "General",
+        slug: "general",
+        permission: 1,
+        topic_template: null,
+      },
+      {
+        id: 2,
+        name: "Category with custom field",
+        slug: "category-custom-field",
+        permission: 1,
+        topic_template: "",
+        custom_fields: {
+          create_topic_wizard: "21",
+        },
+      },
+      {
+        id: 3,
+        name: "Category 1",
+        slug: "category-1",
+        permission: 1,
+        topic_template: "",
+      },
+      {
+        id: 4,
+        name: "Category 2",
+        slug: "category-2",
+        permission: 1,
+        topic_template: "",
+      },
+    ],
+  });
+
+  test("displays all categories", async function (assert) {
+    const categoryChooser = selectKit(".category-chooser");
+    await visit("/");
+    await click("#create-topic");
+    await categoryChooser.expand();
+    let categories = Array.from(
+      document.querySelectorAll(".category-chooser .category-row")
+    ).filter((category) => category.getAttribute("data-name")); // Filter elements with a data-name attribute
+    assert.equal(
+      categories.length,
+      4,
+      "Correct number of categories are displayed"
+    );
+    const categoryNames = [
+      "General",
+      "Category 1",
+      "Category 2",
+      "Category with custom field",
+    ];
+
+    categoryNames.forEach((categoryName) => {
+      assert.ok(
+        categories.some(
+          (category) => category.getAttribute("data-name") === categoryName
+        ),
+        `Category '${categoryName}' is displayed`
+      );
+    });
   });
 });

--- a/test/javascripts/acceptance/category-chooser-initializer-test.js
+++ b/test/javascripts/acceptance/category-chooser-initializer-test.js
@@ -4,7 +4,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 
 acceptance("Category Chooser Initializer for regular users", function (needs) {
-  needs.user({ staff: false, admin: false, moderator: false });
+  needs.user({ admin: false, moderator: false });
   needs.settings({
     allow_uncategorized_topics: false,
   });


### PR DESCRIPTION
This PR introduces a change to the `category-chooser` component to display all categories for admin and staff users. Regular and not-logged-in users will still see the filtered list of categories.

### Changes:
- Added a condition to bypass the category filter for admin and staff users.