### PR TITLE
Tweak readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,12 @@ The Custom Wizard Plugin lets you make forms for your Discourse forum. Better us
 
 If you're not sure how to install a plugin in Discourse, please follow the [plugin installation guide](https://meta.discourse.org/t/install-a-plugin/19157) or contact your Discourse hosting provider.
 
+##  Subscriptions
+You can install the plugin right away and use the basic features. If you need more, we offer [several subscription options](https://custom-wizard.pavilion.tech/pricing), including a community subscription for smaller non-profit and charitable sites. 
+
 ## Documentation
 
-[Read the full documentation here](https://pavilion.tech/products/discourse-custom-wizard-plugin/documentation/), or go directly to the relevant section
-
-- [Wizard Administration](https://coop.pavilion.tech/t/1602)
-- [Wizard Settings](https://coop.pavilion.tech/t/1614)
-- [Step Settings](https://pavilion.tech/products/discourse-custom-wizard-plugin/documentation/step-settings)
-- [Field Settings](https://pavilion.tech/products/discourse-custom-wizard-plugin/documentation/field-settings)
-- [Conditional Settings](https://pavilion.tech/products/discourse-custom-wizard-plugin/documentation/conditional-settings)
-- [Field Interpolation](https://pavilion.tech/products/discourse-custom-wizard-plugin/documentation/field-interpolation)
-- [Handling Dates and Times](https://coop.pavilion.tech/t/1708)
+- [Read the full documentation here](https://coop.pavilion.tech/docs?ascending=true&category=82&order=title)
 
 ## Support
 

--- a/assets/javascripts/discourse/mixins/subscription.js.es6
+++ b/assets/javascripts/discourse/mixins/subscription.js.es6
@@ -3,7 +3,7 @@ import { getOwner } from "@ember/application";
 import { readOnly } from "@ember/object/computed";
 import discourseComputed from "discourse-common/utils/decorators";
 
-const PRODUCT_PAGE = "https://custom-wizard.pavilion.tech";
+const PRODUCT_PAGE = "https://custom-wizard.pavilion.tech/pricing";
 const SUPPORT_MESSAGE =
   "https://coop.pavilion.tech/new-message?username=support&title=Custom%20Wizard%20Support";
 const MANAGER_CATEGORY =

--- a/assets/javascripts/discourse/services/subscription.js
+++ b/assets/javascripts/discourse/services/subscription.js
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
-const PRODUCT_PAGE = "https://custom-wizard.pavilion.tech";
+const PRODUCT_PAGE = "https://custom-wizard.pavilion.tech/pricing";
 const SUPPORT_MESSAGE =
   "https://coop.pavilion.tech/new-message?username=support&title=Custom%20Wizard%20Support";
 const MANAGER_CATEGORY =

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.5.4
+# version: 2.5.5
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Juan Marcos Gutierrez Ramos
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.5.5
+# version: 2.6.1
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Juan Marcos Gutierrez Ramos
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
Brings Readme into line with current gem subscription situation.

Also changes the destination of the Subscribe button in /admin/wizards/wizard to https://custom-wizard.pavilion.tech/pricing. This reduces a redundant step/click in the subscription flow for users. 