### PR TITLE
Do not pass :for_input to super if it was used for tag groups

### DIFF
--- a/lib/custom_wizard/extensions/discourse_tagging.rb
+++ b/lib/custom_wizard/extensions/discourse_tagging.rb
@@ -13,6 +13,7 @@ module CustomWizardDiscourseTagging
 
       opts[:only_tag_names] ||= []
       opts[:only_tag_names].push(*filtered_tags)
+      opts.delete(:for_input)
     end
 
     super


### PR DESCRIPTION
After testing this further, I am convinced that this is the issue (and the solution)

The plugin reuses the for_input tag to designate tags from specific tag groups.

However, core expects that :for_input is used with a category, and if there are tag group restrictions it will honor them.

If :for_input is passed to core without a category, any tags that contain to a tag group that is used in ANY category as a restricted tag group, are not returned.

This makes the plugin unusable for assigning tags from restricted tag groups to a topic.

At the moment CW uses the tag picker, it's not clear to which category the topic is going to be in, so passing the category together with :for_input is not an option.

The only option left to make this work is to remove :for_input.

This behavior is the same in the "experimental form templates" functionality, that also ignores restrictions on tag groups.