### PR TITLE
Update for new core plugin compiler

### DIFF
--- a/assets/javascripts/discourse/components/wizard-value-list.js
+++ b/assets/javascripts/discourse/components/wizard-value-list.js
@@ -1,12 +1,20 @@
-import ValueList from "admin/components/value-list";
+import { optionalRequire } from "discourse/lib/utilities";
 
-export default ValueList.extend({
-  _saveValues() {
-    if (this.inputType === "array") {
-      this.onChange(this.collection);
-      return;
-    }
+const ValueList = optionalRequire("admin/components/value-list");
 
-    this.onChange(this.collection.join(this.inputDelimiter || "\n"));
-  },
-});
+let WizardValueList;
+
+if (ValueList) {
+  ValueList.extend({
+    _saveValues() {
+      if (this.inputType === "array") {
+        this.onChange(this.collection);
+        return;
+      }
+
+      this.onChange(this.collection.join(this.inputDelimiter || "\n"));
+    },
+  });
+}
+
+export default WizardValueList;

--- a/assets/javascripts/discourse/initializers/custom-wizard-dynamic-schema.js
+++ b/assets/javascripts/discourse/initializers/custom-wizard-dynamic-schema.js
@@ -1,0 +1,14 @@
+import wizardSchema from "../lib/wizard-schema";
+
+export default {
+  initialize(container) {
+    const siteSettings = container.lookup("service:site-settings");
+    if (siteSettings.wizard_apis_enabled) {
+      wizardSchema.action.types.send_to_api = {
+        api: null,
+        api_endpoint: null,
+        api_body: null,
+      };
+    }
+  },
+};

--- a/assets/javascripts/discourse/lib/wizard-schema.js
+++ b/assets/javascripts/discourse/lib/wizard-schema.js
@@ -288,15 +288,6 @@ export function filterValues(currentWizard, feature, attribute, values = null) {
   return values;
 }
 
-const siteSettings = getOwnerWithFallback(this).lookup("service:site-settings");
-if (siteSettings.wizard_apis_enabled) {
-  wizardSchema.action.types.send_to_api = {
-    api: null,
-    api_endpoint: null,
-    api_body: null,
-  };
-}
-
 export function setWizardDefaults(obj, itemType) {
   const objSchema = wizardSchema[itemType];
   const basicDefaults = objSchema.basic;


### PR DESCRIPTION
- Module-level code is now evaluated earlier, so site-settings are not available. Move that logic to an initializer

- Importing admin modules from non-admin code will now raise an error. Updated to use `optionalRequire()`

https://meta.discourse.org/t/398713