### PR TITLE
Fix: this.done is not a function on wizard upload field

### DIFF
--- a/assets/javascripts/discourse/components/custom-wizard-field-upload.js
+++ b/assets/javascripts/discourse/components/custom-wizard-field-upload.js
@@ -19,7 +19,6 @@ export default class CustomWizardFieldUpload extends Component {
           "field.value": upload,
           isImage: this.imageUploadFormats.includes(upload.extension),
         });
-        this.done();
       },
     });
     this.uppyUpload.setup(document.getElementById(this.inputId));

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-custom-wizard
 # about: Forms for Discourse. Better onboarding, structured posting, data enrichment, automated actions and much more.
-# version: 2.14.1
+# version: 2.14.2
 # authors: Angus McLeod, Faizaan Gagan, Robert Barrow, Keegan George, Kaitlin Maddever, Marcos Gutierrez
 # url: https://github.com/paviliondev/discourse-custom-wizard
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
In custom-wizard-field-upload.js, the uploadDone callback calls this.done(), but done is not defined on CustomWizardFieldUpload — it is neither a method on the class, nor declared in its template, nor passed in by any caller. done is only defined as an action on the unrelated custom-wizard-step component and is never wired into the upload field.
On a successful upload this throws this.done is not a function, which Uppy catches and surfaces as an error dialog to the user, even though the upload itself succeeds (field.value is set before the failing call). The orphaned call is a leftover from a previous implementation.
Fix: remove the orphaned this.done() call. The upload result is already persisted via field.value, the loading state is tracked reactively through uppyUpload.uploading, and the preview renders from field.value, so no behavior is lost.